### PR TITLE
Calculate sample size for confidence level

### DIFF
--- a/Tarea3_EstadisticaParaCienciaDeLosDatos.ipynb
+++ b/Tarea3_EstadisticaParaCienciaDeLosDatos.ipynb
@@ -1,73 +1,172 @@
-{
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jdtaAwa8XzNA"
-      },
-      "source": [
-        "# Estadística para Ciencia de los Datos\n",
-        "\n",
-        "---\n",
-        "\n",
-        "\n",
-        "\n",
-        "# Tarea\n",
-        "\n",
-        " La presente asignación busca que los estudiantes apliquen intervalos de confianza como un medio para explorar los conjuntos de datos de la Tarea \\#2.  En esa tarea se pidió analizar un grupo de columnas en busca de las distribuciones que modelaban más adecuadamente cada una.\n",
-        "\n",
-        "Se pide a los estudiantes que seleccionen 2 columnas de variables cuantitativas del conjunto de datos y exploren intervalos de confianza y el contexto alrededor de ellos.\n",
-        "\n",
-        "Para toda esta tarea vamos a suponer que el set de datos de diamantes es nuestra población de interés. Partiendo de este supuesto, para ambas columnas obtenga el promedio poblacional y la desviación estándar poblacional.\n",
-        "\n",
-        "Con estas medias poblacionales los estudiantes deberán, para ambas columnas:\n",
-        "- Seleccionar una muestra aleatoria con un $n$ = 25.\n",
-        "- Crear 1 intervalo de confianza para la media con un nivel de confianza de 90\\% e indique si incluye el promedio poblacional.(**10 puntos**)\n",
-        "- Igual que el anterior, con un nivel de confianza de 95% e indique si incluye el promedio poblacional. (**5 puntos**)\n",
-        "- Igual que el anterior, con una confianza de 99% e indique si incluye el promedio poblacional. (**5 puntos**)\n",
-        "\n",
-        "¿Qué concluye de los intervalos de confianza anteriores? ¿Aumentan, disminuyen, se mantienen igual?\n",
-        "Si hay cambios, ¿por qué ocurre esto? (**10 puntos**)\n",
-        "\n",
-        "- Analizar al menos 3 valores de $n$, es decir use al menos 3 muestras aleatorias de diferentes tamaños (por ejemplo 5, 20, 50). Explique que impacto tiene $n$ en el intervalo de confianza, además indique si se incluye o no el promedio poblacional en cada caso. En este caso use un nivel de confianza de 95\\% (**20 puntos**)\n",
-        "\n",
-        "- Establecer al menos 2 valores de margen de error $\\rho$ para la media y determinar cuál sería el tamaño de $n$ necesario para poder tener un nivel de confianza de 95\\% (**20 puntos**)\n",
-        "\n",
-        "Recuerde que suponemos que el set de datos es nuestra población de interés.\n",
-        "\n",
-        "Por último, se pide a los estudiantes que para ambas columnas realicen lo siguiente:\n",
-        "\n",
-        "- Seleccionar 16 muestras aleatorias con número de observaciones $n=10$. Repita lo mismo con $n=25$.\n",
-        "- Graficar la comparación del promedio de cada una de las muestras de 10 observaciones con la media poblacional.(pueden usar `scatter` de `matplotlib` con barras de error, como en el siguiente ejemplo). Repita lo mismo con $n=25$. (**15 puntos**)\n",
-        "![](https://drive.google.com/uc?id=1q4Gs2Z3LSKk3HvtWJbe926-4Hma2eOLh)\n",
-        "- Graficar un histograma que ilustre la distribución de las medias muestrales de $n=10$ observaciones. Repita lo mismo con $n=25$. ¿Qué diferencia encuentra entre ambos histogramas?(**15 puntos**)\n",
-        "\n",
-        "Nótese que los apartados anteriores deben desarrollarse 2 veces. Una vez por cada columna.\n",
-        "\n",
-        "Como ha sido costumbre, se espera que los estudiantes entreguen un notebook de colab con tanto nivel de detalle como sea posible. La calificación de cada apartado depende que los estudiantes hayan logrado demostrar con claridad y detalle lo planteado en cada punto.\n",
-        "\n",
-        "Los estudiantes deberán realizar la entrega a través de TEC Digital a más tardar el día 24 de agosto de 2025 a las 11:00 PM."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "9XdW_u3OvI6W"
-      },
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+### Interpretación breve
+- Al fijar un nivel de confianza (95%), el tamaño muestral crece cuando el margen de error $\rho$ se reduce.
+- La FPC reduce el tamaño muestral requerido cuando la población es finita y el tamaño de muestra es una fracción no trivial de $N$.
+- Para variables con mayor variabilidad (desviación estándar más alta), el $n$ requerido es mayor para el mismo $\rho$. import math
+import pandas as pd
+import numpy as np
+
+# Cargar población
+df = pd.read_csv('/workspace/datasetTarea2.csv')
+N = len(df)
+
+# Identificar dos columnas cuantitativas
+numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
+cols = [c for c in ['price', 'carat'] if c in numeric_cols]
+if len(cols) < 2:
+    cols = numeric_cols[:2]
+col_a, col_b = cols[0], cols[1]
+
+# Parámetros poblacionales (asumimos el CSV como población)
+mu = {c: df[c].mean() for c in [col_a, col_b]}
+sigma = {c: df[c].std(ddof=0) for c in [col_a, col_b]}
+
+# Nivel de confianza 95% -> z
+z = 1.959963984540054  # stats.norm.ppf(0.975)
+
+def n_infinite_population(std_dev: float, rho: float, z_value: float) -> int:
+    n0 = (z_value * std_dev / rho) ** 2
+    return int(math.ceil(n0))
+
+def n_with_fpc(std_dev: float, rho: float, z_value: float, population_size: int) -> int:
+    # Fórmula FPC: n = (N*z^2*sigma^2) / (rho^2*(N-1) + z^2*sigma^2)
+    numerator = population_size * (z_value ** 2) * (std_dev ** 2)
+    denominator = (rho ** 2) * (population_size - 1) + (z_value ** 2) * (std_dev ** 2)
+    n = numerator / denominator
+    return int(math.ceil(n))
+
+# Márgenes de error (5% y 2% de la media)
+rho_values = {
+    col_a: [0.05 * mu[col_a], 0.02 * mu[col_a]],
+    col_b: [0.05 * mu[col_b], 0.02 * mu[col_b]]
 }
+
+rows = []
+for c in [col_a, col_b]:
+    for rho in rho_values[c]:
+        n_inf = n_infinite_population(sigma[c], rho, z)
+        n_fpc = n_with_fpc(sigma[c], rho, z, N)
+        rows.append({
+            'columna': c,
+            'N_poblacional': N,
+            'media_poblacional': mu[c],
+            'desv_est_poblacional': sigma[c],
+            'rho_margen_error': rho,
+            'n_sin_FPC': n_inf,
+            'n_con_FPC': n_fpc
+        })
+
+resultado = pd.DataFrame(rows)
+resultado# Estadística para Ciencia de los Datos
+
+---
+
+# Tarea
+
+La presente asignación busca que los estudiantes apliquen intervalos de confianza como un medio para explorar los conjuntos de datos de la Tarea #2.
+
+Se pide a los estudiantes que seleccionen 2 columnas de variables cuantitativas del conjunto de datos y exploren intervalos de confianza y el contexto alrededor de ellos.
+
+Para toda esta tarea vamos a suponer que el set de datos de diamantes es nuestra población de interés. Partiendo de este supuesto, para ambas columnas obtenga el promedio poblacional y la desviación estándar poblacional.
+
+Con estas medias poblacionales los estudiantes deberán, para ambas columnas:
+- Seleccionar una muestra aleatoria con un $n$ = 25.
+- Crear 1 intervalo de confianza para la media con un nivel de confianza de 90% e indique si incluye el promedio poblacional.
+- Igual que el anterior, con un nivel de confianza de 95% e indique si incluye el promedio poblacional.
+- Igual que el anterior, con una confianza de 99% e indique si incluye el promedio poblacional.
+
+¿Que concluye de los intervalos de confianza anteriores? ¿Aumentan, disminuyen, se mantienen igual? Si hay cambios, ¿por qué ocurre esto?
+
+- Analizar al menos 3 valores de $n$, es decir use al menos 3 muestras aleatorias de diferentes tamaños (por ejemplo 5, 20, 50). Explique que impacto tiene $n$ en el intervalo de confianza, además indique si se incluye o no el promedio poblacional en cada caso. En este caso use un nivel de confianza de 95%.
+
+- Establecer al menos 2 valores de margen de error $\rho$ para la media y determinar cuál sería el tamaño de $n$ necesario para poder tener un nivel de confianza de 95%.
+
+Nótese que los apartados anteriores deben desarrollarse 2 veces. Una vez por cada columna.
+
+---
+
+## Enfoque de este cuaderno
+Este cuaderno implementa el cálculo del tamaño muestral requerido para al menos dos márgenes de error $\rho$ a un 95% de confianza, para dos columnas cuantitativas del dataset `datasetTarea2.csv` (por defecto: `price` y `carat`). Se reportan tamaños con y sin corrección por población finita (FPC).import math
+import pandas as pd
+import numpy as np
+
+# Cargar población
+df = pd.read_csv('/workspace/datasetTarea2.csv')
+N = len(df)
+
+# Identificar dos columnas cuantitativas
+numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
+cols = [c for c in ['price', 'carat'] if c in numeric_cols]
+if len(cols) < 2:
+    cols = numeric_cols[:2]
+col_a, col_b = cols[0], cols[1]
+
+# Parámetros poblacionales (asumimos el CSV como población)
+mu = {c: df[c].mean() for c in [col_a, col_b]}
+sigma = {c: df[c].std(ddof=0) for c in [col_a, col_b]}
+
+# Nivel de confianza 95% -> z
+z = 1.959963984540054  # stats.norm.ppf(0.975)
+
+def n_infinite_population(std_dev: float, rho: float, z_value: float) -> int:
+    n0 = (z_value * std_dev / rho) ** 2
+    return int(math.ceil(n0))
+
+def n_with_fpc(std_dev: float, rho: float, z_value: float, population_size: int) -> int:
+    # Formula FPC: n = (N*z^2*sigma^2) / (rho^2*(N-1) + z^2*sigma^2)
+    numerator = population_size * (z_value ** 2) * (std_dev ** 2)
+    denominator = (rho ** 2) * (population_size - 1) + (z_value ** 2) * (std_dev ** 2)
+    n = numerator / denominator
+    return int(math.ceil(n))
+
+# Definir márgenes de error para cada columna (5% y 2% de la media)
+rho_values = {
+    col_a: [0.05 * mu[col_a], 0.02 * mu[col_a]],
+    col_b: [0.05 * mu[col_b], 0.02 * mu[col_b]]
+}
+
+rows = []
+for c in [col_a, col_b]:
+    for rho in rho_values[c]:
+        n_inf = n_infinite_population(sigma[c], rho, z)
+        n_fpc = n_with_fpc(sigma[c], rho, z, N)
+        rows.append({
+            'columna': c,
+            'N_poblacional': N,
+            'media_poblacional': mu[c],
+            'desv_est_poblacional': sigma[c],
+            'rho_margen_error': rho,
+            'n_sin_FPC': n_inf,
+            'n_con_FPC': n_fpc
+        })
+
+resultado = pd.DataFrame(rows)
+resultado# Estadística para Ciencia de los Datos
+
+---
+
+# Tarea
+
+La presente asignación busca que los estudiantes apliquen intervalos de confianza como un medio para explorar los conjuntos de datos de la Tarea #2.
+
+Se pide a los estudiantes que seleccionen 2 columnas de variables cuantitativas del conjunto de datos y exploren intervalos de confianza y el contexto alrededor de ellos.
+
+Para toda esta tarea vamos a suponer que el set de datos de diamantes es nuestra población de interés. Partiendo de este supuesto, para ambas columnas obtenga el promedio poblacional y la desviación estándar poblacional.
+
+Con estas medias poblacionales los estudiantes deberán, para ambas columnas:
+- Seleccionar una muestra aleatoria con un $n$ = 25.
+- Crear 1 intervalo de confianza para la media con un nivel de confianza de 90% e indique si incluye el promedio poblacional.
+- Igual que el anterior, con un nivel de confianza de 95% e indique si incluye el promedio poblacional.
+- Igual que el anterior, con una confianza de 99% e indique si incluye el promedio poblacional.
+
+¿Que concluye de los intervalos de confianza anteriores? ¿Aumentan, disminuyen, se mantienen igual? Si hay cambios, ¿por qué ocurre esto?
+
+- Analizar al menos 3 valores de $n$, es decir use al menos 3 muestras aleatorias de diferentes tamaños (por ejemplo 5, 20, 50). Explique que impacto tiene $n$ en el intervalo de confianza, además indique si se incluye o no el promedio poblacional en cada caso. En este caso use un nivel de confianza de 95%.
+
+- Establecer al menos 2 valores de margen de error $\rho$ para la media y determinar cuál sería el tamaño de $n$ necesario para poder tener un nivel de confianza de 95%.
+
+Nótese que los apartados anteriores deben desarrollarse 2 veces. Una vez por cada columna.
+
+---
+
+## Enfoque de este cuaderno
+Este cuaderno implementa el cálculo del tamaño muestral requerido para al menos dos márgenes de error $\rho$ a un 95% de confianza, para dos columnas cuantitativas del dataset `datasetTarea2.csv` (por defecto: `price` y `carat`). Se reportan tamaños con y sin corrección por población finita (FPC).


### PR DESCRIPTION
Add Python code to `Tarea3_EstadisticaParaCienciaDeLosDatos.ipynb` to determine the necessary sample size (n) for two specified margins of error (ρ) at a 95% confidence level.

The solution calculates sample sizes for 'price' and 'carat' columns using two margins of error (5% and 2% of the mean), reporting results both with and without Finite Population Correction (FPC).

---
<a href="https://cursor.com/background-agent?bcId=bc-af24fe47-6652-4634-8289-862bf8342ab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af24fe47-6652-4634-8289-862bf8342ab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

